### PR TITLE
post: may 2025 bitdevs

### DIFF
--- a/_posts/2025-05-08-socratic-seminar-64.md
+++ b/_posts/2025-05-08-socratic-seminar-64.md
@@ -1,0 +1,24 @@
+---
+layout: post
+type: socratic
+title: "Socratic Seminar 65"
+meetup: https://www.meetup.com/chibitdevs/events/307363811
+---
+
+## Announcements
+
+Please join us for our next Socratic Seminar! A sepcial thanks to Strike for the event space.
+
+Doors open at 6pm with discussion starting shortly after!
+
+[Follow ChiBitDevs on twitter](https://x.com/chibitdevs)
+
+## Presentation: Stable Channels (@tonklaus presents)
+
+<https://github.com/toneloc/stable-channels>
+<https://x.com/tonklaus/status/1918258692337676433>
+
+## Discussion: OP_RETURN
+
+<https://delvingbitcoin.org/t/op-checkcontractverify-and-its-amount-semantic/1527>
+<https://groups.google.com/g/bitcoindev/c/d6ZO7gXGYbQ>


### PR DESCRIPTION
closes https://github.com/ChicagoBitdevs/ChicagoBitdevs.github.io/issues/128

@GambolingPangolin let me know if there is any formatting issues

I also just added some popular repo's and commits that were merged since last seminar and also the bitcoin op_tech links

lemme know if you want anything changed!