### PR TITLE
adds nostr nip05 identifier

### DIFF
--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -1,0 +1,8 @@
+{
+  "names": {
+    "_": "338d64ebe4066a3ba49dc3b158a6fce7b4a2a3cca56d9023c8c5027b262cb37d"
+  },
+  "relays": {
+    "338d64ebe4066a3ba49dc3b158a6fce7b4a2a3cca56d9023c8c5027b262cb37d": ["wss://nos.lol", "wss://relay.damus.io", "wss://nostr.wine", "wss://nostr.land", "wss://relay.npub.bar"]
+  }
+}

--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,7 @@ exclude: ['README.md', 'Gemfile', 'Gemfile.lock', '.sass-cache']
 
 # Publish all posts even if the date is in the future
 future: true
+
+# Include .well-known directory
+include:
+ - .well-known


### PR DESCRIPTION
this theoretically adds the nostr nip05 identifier for the chi bit devs nostr account (I tested locally and it works... but you never know until its live heheh). shouldn't bring down site or anything, just includes an additional directory to serve.

I figure the chi bit devs nostr account should use chibitdevs.org domain as its nip05 internet id since its more official.